### PR TITLE
Fixed multi-line comments.

### DIFF
--- a/jlox/src/jlox/Scanner.java
+++ b/jlox/src/jlox/Scanner.java
@@ -138,15 +138,16 @@ public class Scanner {
 
 			if (isBeginComment) {
 				commentDepth++;				
+				advance();
 			}
 
 			if (isEndComment) {
 				commentDepth--;
+				advance();
 			}
 
 			if (commentDepth < 1) {				
 				fullyEnclosed = true;
-				advance();
 			}
 
 			advance();


### PR DESCRIPTION
Multi-line comments would omit following tokens in previous implementation. 'advance()'s where placed in the wrong positions.